### PR TITLE
fix: update rtd build system for deprecation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,12 @@
 version: 2
-sphinx:
-  configuration: doc/source/conf.py
 
-python:
-    version: 3.7
-    install:
-      - requirements: doc/requirements.txt
+sphinx:
+  builder: html
+  configuration: doc/source/conf.py
+  install:
+    - requirements: doc/requirements.txt
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"


### PR DESCRIPTION
Update readthedocs build system due to changes in build system v2
https://docs.readthedocs.io/en/stable/config-file/v2.html#build
